### PR TITLE
Check if `exact` exists in the array before accessing it

### DIFF
--- a/opencloudmesh/lib/ShareeSearchPlugin.php
+++ b/opencloudmesh/lib/ShareeSearchPlugin.php
@@ -205,7 +205,7 @@ class ShareeSearchPlugin implements IRemoteShareesSearch {
 				],
 			];
 		}
-		if (isset($this->result) && count($this->result) > 0 )
+		if (isset($this->result) && count($this->result) > 0 && isset($this->result['exact']))
 			return $this->result['exact']['remotes'];
 		return [];
 	}


### PR DESCRIPTION
Simple (noobish) check to avoid throwing 
```
"message":"Undefined index: exact
```
while using search box in GUI



