### PR TITLE
Fixed compatibility with sciencemesh

### DIFF
--- a/opencloudmesh/lib/FederatedFileSharing/AbstractFedShareManager.php
+++ b/opencloudmesh/lib/FederatedFileSharing/AbstractFedShareManager.php
@@ -88,7 +88,7 @@ abstract class AbstractFedShareManager {
 	/**
 	 * AbstractFedShareManager constructor.
 	 *
-	 * @param AbstractFederatedShareProvider $federatedShareProvider
+	 * @param $federatedShareProvider
 	 * @param AbstractNotifications $notifications
 	 * @param IUserManager $userManager
 	 * @param ActivityManager $activityManager
@@ -98,7 +98,7 @@ abstract class AbstractFedShareManager {
 	 * @param EventDispatcherInterface $eventDispatcher
 	 */
 	public function __construct(
-		AbstractFederatedShareProvider $federatedShareProvider,
+		$federatedShareProvider,
 		AbstractNotifications $notifications,
 		IUserManager $userManager,
 		ActivityManager $activityManager,

--- a/opencloudmesh/lib/FederatedFileSharing/FedUserShareManager.php
+++ b/opencloudmesh/lib/FederatedFileSharing/FedUserShareManager.php
@@ -47,7 +47,7 @@ class FedUserShareManager extends AbstractFedShareManager {
 	/**
 	 * FedShareManager constructor.
 	 *
-	 * @param FederatedUserShareProvider $federatedUserShareProvider
+	 * @param $federatedUserShareProvider
 	 * @param UserNotifications $notifications
 	 * @param IUserManager $userManager
 	 * @param ActivityManager $activityManager
@@ -57,7 +57,7 @@ class FedUserShareManager extends AbstractFedShareManager {
 	 * @param EventDispatcherInterface $eventDispatcher
 	 */
 	public function __construct(
-		FederatedUserShareProvider $federatedUserShareProvider,
+		$federatedUserShareProvider,
 		UserNotifications $notifications,
 		IUserManager $userManager,
 		ActivityManager $activityManager,


### PR DESCRIPTION
Sciencemesh's `ShareProviderFactory` returns an instance of `ScienceMeshShareProvider` which then is fed to OpenCloudMesh's `FedUserShareManager`. But `FedUserShareManager` expects an instance of `FederatedUserShareProvider`. The test failed because of a type mismatch. The quickest solution to this is to remove the types on the `FedUserShareManager`.